### PR TITLE
secure DOIs

### DIFF
--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -3,5 +3,5 @@
 {{reference}}
 {% if entry.doi %}
 <input type="button" value="Direct link"
-onclick="window.open('http://dx.doi.org/{{entry.doi}}')">
+onclick="window.open('https://doi.org/{{entry.doi}}')">
 {% endif %}


### PR DESCRIPTION
According to https://www.doi.org/doi_handbook/3_Resolution.html#3.8 dx.doi.org is no longer preferred and since https is supported, I suggest to go the whole way ;-)
